### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
-.terraform
-terraform.tfstate*
 terraform-provider-upcloud
 crash.log
 *.tf
+terraform.tfstate*
+.git
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Build the binary in a separate container
+FROM golang:1.9-alpine3.6 AS builder
+RUN mkdir -p /go/src/app
+WORKDIR /go/src/app
+COPY . /go/src/app
+RUN go-wrapper install
+
+# Copy provider to final container
+FROM alpine:3.6
+MAINTAINER Ville Törhönen <ville@torhonen.fi>
+ENV TERRAFORM_VERSION 0.10.6
+RUN set -x \
+    && apk add --no-cache \
+        ca-certificates \
+    && apk add --no-cache --virtual .build-deps \
+        unzip \
+	    curl \
+    && curl -sLo /tmp/terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+    && unzip /tmp/terraform.zip -d /usr/local/bin \
+    && rm -f /tmp/terraform.zip \
+    && apk del .build-deps
+COPY --from=builder /go/bin/terraform-provider-upcloud /usr/local/bin/terraform-provider-upcloud
+ENTRYPOINT ["/usr/local/bin/terraform"]

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main
+package main // import "github.com/vtorhonen/terraform-provider-upcloud"
 
 import (
 	"github.com/hashicorp/terraform/plugin"


### PR DESCRIPTION
Add Dockerfile for running provider inside a container. Will be useful for CI purposes and testing.

Uses multi-stage builds on Alpine 3.6. Docker CE >=17.05 is required.