### PR TITLE
Fix typo in user_data parameter handling

### DIFF
--- a/upcloud/resource_upcloud_server.go
+++ b/upcloud/resource_upcloud_server.go
@@ -223,7 +223,7 @@ func buildServerOpts(d *schema.ResourceData, meta interface{}) (*request.CreateS
 	if attr, ok := d.GetOk("mem"); ok {
 		r.MemoryAmount = attr.(int)
 	}
-	if attr, ok := d.GetOk("userdata"); ok {
+	if attr, ok := d.GetOk("user_data"); ok {
 		r.UserData = attr.(string)
 	}
 


### PR DESCRIPTION
Previously instance `user_data` was not passed on properly.

Now that this is fixed `user_data` scripts can be used by templating them in Terraform.

```
data "template_file" "bootstrap" {
    template = "${file("${path.module}/user_data.sh")}"
}

resource "upcloud_server" "test" {
    ...
    user_data = "${data.template_file.bootstrap.rendered}"
}
```