### PR TITLE
Implement login definitions for servers

### DIFF
--- a/examples/01_server.tf
+++ b/examples/01_server.tf
@@ -23,4 +23,13 @@ resource "upcloud_server" "test" {
     # OS root disk size
     os_disk_size = 20
 
+    # Login details
+    login {
+        user = "tf"
+        keys = [
+            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCYn6VuEgiH3//qpSa/b3Khrjy3Z4Q4fvvhRNRDrZaJqddLvQLCtoL2ktoke7+0jTcR4Vydi8bk8csUQlZxpWC6SIfif+tB8HjwusbUfLT5I5fJEI/O7gtktvtWkK4GnePFXYIdgKlXKRJ92xFnNOGV+el2zug78QahsrzsyV0Cucfjb7twPyojh5iPl3gf6f7NBHVnsqNELhJqmpo4uY+vSTfHx0siyIGP0U/Jz9dB64kbnoG6GL2fh3CEQ950Ll2luY/cfX52SO+WX/nl156A2VVCozkOSE3wbZ501Gd1508KY7ctuaqOue4DF8ZuQ1uzv4Lf9sfg4Bv4jBMTu4tvB"
+        ]
+        create_password = true
+        password_delivery = "sms"
+    }
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,14 @@
 # Examples for terraform-provider-upcloud
 
+This is a full example which shows how you can set up your own UpCloud instance by using Terraform.
+
+## Initializing local environment
+
 First install this provider and initialize Terraform in this directory.
 
 ```
+$ git clone https://github.com/vtorhonen/terraform-upcloud-provider
+$ cd terraform-upcloud-provider/examples
 $ go install github.com/vtorhonen/terraform-upcloud-provider
 $ terraform init
 
@@ -10,6 +16,12 @@ Initializing provider plugins...
 
 Terraform has been successfully initialized!
 ```
+
+## Configuring the plan
+
+Set up your credentials to `01_server.tf`. Modify `login` block accordingly and set up your own SSH keys.
+In this example you can also remove `keys` parameter, since UpCloud will auto generate a password for you
+and deliver it via SMS.
 
 Plan your changes.
 
@@ -37,6 +49,12 @@ Terraform will perform the following actions:
       ipv4_address_private: <computed>
       ipv6:                 "true"
       ipv6_address:         <computed>
+      login.#:                           "1"
+      login.868081814.create_password:   "true"
+      login.868081814.keys.#:            "1"
+      login.868081814.keys.0:            "ssh-rsa <snip>"
+      login.868081814.password_delivery: "sms"
+      login.868081814.user:              "tf"
       mem:                  "2048"
       os_disk_size:         "20"
       os_disk_tier:         "maxiops"
@@ -49,32 +67,48 @@ Terraform will perform the following actions:
 Plan: 1 to add, 0 to change, 0 to destroy.
 ```
 
-Then apply the plan.
+## Applying the plan
+
+Apply the plan by running `terraform apply`.
 
 ```
 $ terraform apply
 upcloud_server.test: Creating...
-  cpu:                  "" => "2"
-  hostname:             "" => "my-awesome-hostname"
-  ipv4:                 "" => "true"
-  ipv4_address:         "" => "<computed>"
-  ipv4_address_private: "" => "<computed>"
-  ipv6:                 "" => "true"
-  ipv6_address:         "" => "<computed>"
-  mem:                  "" => "2048"
-  os_disk_size:         "" => "20"
-  os_disk_tier:         "" => "maxiops"
-  os_disk_uuid:         "" => "<computed>"
-  private_networking:   "" => "true"
-  template:             "" => "CentOS 7.0"
-  title:                "" => "<computed>"
-  zone:                 "" => "fi-hel1"
+  cpu:                               "" => "2"
+  hostname:                          "" => "my-awesome-hostname"
+  ipv4:                              "" => "true"
+  ipv4_address:                      "" => "<computed>"
+  ipv4_address_private:              "" => "<computed>"
+  ipv6:                              "" => "true"
+  ipv6_address:                      "" => "<computed>"
+  login.#:                           "" => "1"
+  login.868081814.create_password:   "" => "true"
+  login.868081814.keys.#:            "" => "1"
+  login.868081814.keys.0:            "" => "<snip>"
+  login.868081814.password_delivery: "" => "sms"
+  login.868081814.user:              "" => "tf"
+  mem:                               "" => "2048"
+  os_disk_size:                      "" => "20"
+  os_disk_tier:                      "" => "maxiops"
+  os_disk_uuid:                      "" => "<computed>"
+  private_networking:                "" => "true"
+  template:                          "" => "CentOS 7.0"
+  title:                             "" => "<computed>"
+  zone:                              "" => "fi-hel1"
 upcloud_server.test: Still creating... (10s elapsed)
 upcloud_server.test: Still creating... (20s elapsed)
 upcloud_server.test: Still creating... (30s elapsed)
 upcloud_server.test: Still creating... (40s elapsed)
 upcloud_server.test: Creation complete after 46s (ID: <snip>)
+
+Outputs:
+
+ip = <SOME IP ADDRESS>
 ```
+
+You can then log in to the server by running `ssh tf@<SOME IP ADDRESS>`. Check your SMS messages if you didn't specify any SSH keys.
+
+## Modifying the plan
 
 Next, increase memory config from 2 GB to 4 GB by changing resource
 config to `mem = 4096`. Then run `terraform plan` again.
@@ -104,7 +138,16 @@ upcloud_server.test: Still modifying... (ID: <snip>, 20s elapsed)
 upcloud_server.test: Still modifying... (ID: <snip>, 30s elapsed)
 upcloud_server.test: Still modifying... (ID: <snip>, 40s elapsed)
 upcloud_server.test: Modifications complete after 40s (ID: <snip>)
+
+Outputs:
+
+ip = <SOME IP ADDRESS>
 ```
+
+Again, log in to the server and verify that memory has been increased.
+
+
+## Cleaning up the environment
 
 You can then destroy the instance by running `terraform destroy`. NOTE: You will lose all data.
 


### PR DESCRIPTION
It is now possible to define login credentials by using a `login` block inside server config. This configuration should at least define a username and a SSH key.

Also, it is possible to let UpCloud generate a password for you and deliver it to you through customizable method `{"none", "email", "sms"}``. However, in terms of automation this is typically not feasible so by default a password is not generated nor delivered.

Example generates user `tf` and associates a SSH key with it.

```
resource "upcloud_server" "test2" {
    ...
    login {
        user = "tf"
        keys = [
                "ssh-rsa ..."
        ]
    }
}
```

Updated docs and example configs.

Fixes #2.