### PR TITLE
Remove username and password definition from example file

### DIFF
--- a/examples/01_server.tf
+++ b/examples/01_server.tf
@@ -1,6 +1,8 @@
 provider "upcloud" {
-    username = "foo"
-    password = "bar"
+    # You need to set UpCloud credentials in shell environment variable
+    # using .bashrc, .zshrc or similar
+    # export UPCLOUD_USERNAME="Username for Upcloud API user"
+    # export UPCLOUD_PASSWORD="Password for Upcloud API user"
 }
 
 resource "upcloud_server" "test" {


### PR DESCRIPTION
Remove username and password definition from example file and use shell environment variables instead. This is better from the security point of view as the credentials are never accidentally pushed to version control in this way.