### PR TITLE
Adjusted the installation instructions and example instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,18 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-upcloud`
+Get and install the provider:
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:vtorhonen/terraform-provider-upcloud.git
+$ go get github.com/vtorhonen/terraform-provider-upcloud
+$ go install github.com/vtorhonen/terraform-provider-upcloud
 ```
 
-Enter the provider directory and build the provider
+Symlink the provider into a folder (also make sure it exists) where Terraform looks for it:
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-upcloud
-$ make build
+$ mkdir -p $HOME/.terraform.d/plugins
+$ ln -s $GOPATH/bin/terraform-provider-upcloud $HOME/.terraform.d/plugins/terraform-provider-upcloud
 ```
 
 Using the provider

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,12 +4,25 @@ This is a full example which shows how you can set up your own UpCloud instance 
 
 ## Initializing local environment
 
-First install this provider and initialize Terraform in this directory.
+First install this provider:
 
+```sh
+$ go get github.com/vtorhonen/terraform-provider-upcloud
+$ go install github.com/vtorhonen/terraform-provider-upcloud
 ```
+
+Symlink the provider into a folder (also make sure it exists) where Terraform looks for it:
+
+```sh
+$ mkdir -p $HOME/.terraform.d/plugins
+$ ln -s $GOPATH/bin/terraform-provider-upcloud $HOME/.terraform.d/plugins/terraform-provider-upcloud
+```
+
+Clone this example and init Terraform in the example folder:
+
+```sh
 $ git clone https://github.com/vtorhonen/terraform-upcloud-provider
 $ cd terraform-upcloud-provider/examples
-$ go install github.com/vtorhonen/terraform-upcloud-provider
 $ terraform init
 
 Initializing provider plugins...


### PR DESCRIPTION
Simplified the installation instructions of the go code and added a step to symlink the provider into a folder where Terraform will find it when running `terraform init`.

This fixes #16.