### PR TITLE
Output server IPv4 address in example configuration

### DIFF
--- a/examples/01_server.tf
+++ b/examples/01_server.tf
@@ -14,7 +14,7 @@ resource "upcloud_server" "test" {
     zone = "fi-hel1"
 
     # Template name or UUID
-    template = "CentOS 7.0"
+    template = "Ubuntu Server 16.04 LTS (Xenial Xerus)"
 
     # Number of vCPUs
     cpu = 2
@@ -34,4 +34,8 @@ resource "upcloud_server" "test" {
         create_password = true
         password_delivery = "sms"
     }
+}
+
+output "ipv4_address" {
+    value = "${upcloud_server.test.ipv4_address}"
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -154,7 +154,7 @@ upcloud_server.test: Modifications complete after 40s (ID: <snip>)
 
 Outputs:
 
-ip = <SOME IP ADDRESS>
+ipv4_address = <SOME IP ADDRESS>
 ```
 
 Again, log in to the server and verify that memory has been increased.


### PR DESCRIPTION
Update example configuration to set state output for server IPv4 address. Also, change example template image from CentOS to Ubuntu as old CentOS minor versions are being pruned while newer version are being rolled out.

Relates to #18.