### PR TITLE
Fix firewall rule deletion

### DIFF
--- a/upcloud/resource_upcloud_firewall_rule.go
+++ b/upcloud/resource_upcloud_firewall_rule.go
@@ -225,7 +225,7 @@ func resourceUpCloudFirewallRuleRead(d *schema.ResourceData, meta interface{}) e
 func resourceUpCloudFirewallRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*service.Service)
 
-	position, err := strconv.Atoi(d.Id())
+	position, err := strconv.Atoi(d.Get("position").(string))
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously firewall rule deletion referenced rules by server ID, which is why firewall rules could not be deleted. This PR fixes it.